### PR TITLE
ci: remove `bors.toml`

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,0 @@
-status = ["build"]
-delete_merged_branches = true


### PR DESCRIPTION
Bors cannot create a sqush merge while setting a PR as merged.
